### PR TITLE
Handle bad inputs better

### DIFF
--- a/phone_iso3166/country.py
+++ b/phone_iso3166/country.py
@@ -34,7 +34,7 @@ def phone_country(phone: typing.Union[str, int]) -> str:
             (int(digit) for digit in phone if digit.isdigit()),
             mapping,
         )
-    except KeyError as ex:
+    except (KeyError, ValueError) as ex:
         raise InvalidPhone("Invalid phone {}".format(phone)) from ex
 
 
@@ -103,7 +103,7 @@ def phone_country_prefix(
             (int(digit) for digit in phone if digit.isdigit()),
             mapping,
         )
-    except KeyError as ex:
+    except (KeyError, ValueError) as ex:
         raise InvalidPhone("Invalid phone {}".format(phone)) from ex
 
 

--- a/tests/test_country.py
+++ b/tests/test_country.py
@@ -51,9 +51,16 @@ def test_country_invalid():
         country_prefix("dkk")
 
 
-def test_invalid():
+@pytest.mark.parametrize(
+    "case",
+    [
+        0,
+        12,
+    ],
+)
+def test_invalid(case):
     with pytest.raises(InvalidPhone):
-        phone_country(0)
+        phone_country(case)
 
 
 def test_missing():


### PR DESCRIPTION
It is possilbe a key will result in nothing due to how the data is
structured, and rather than raising a ValueError because it could
not be split, we would rather like to raise the InvalidPhone error.